### PR TITLE
@typescript-eslint/naming-convention 追加

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,13 @@
     "@typescript-eslint/consistent-type-imports": "error",
     "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/eqeqeq": "off",
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "objectLiteralProperty",
+        "format": ["strictCamelCase"]
+      }
+    ],
     // simple-import-sort
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error",


### PR DESCRIPTION
HTTPヘッダーに大文字を使わないようにしたい