### PR TITLE
pnpm/action-setupやめる

### DIFF
--- a/.github/workflows/_e2e-federation.yml
+++ b/.github/workflows/_e2e-federation.yml
@@ -33,12 +33,11 @@ jobs:
         run: |
           rm -rf .next/e2e/myhost/cache/fetch-cache
           rm -rf .next/e2e/remote/cache/fetch-cache
-      - uses: pnpm/action-setup@v2
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
           cache: pnpm
-      - run: pnpm i
+      - run: corepack enable pnpm && pnpm i
       # https://github.com/FiloSottile/mkcert#linux
       - name: Install mkcert
         run: |

--- a/.github/workflows/_e2e-federation.yml
+++ b/.github/workflows/_e2e-federation.yml
@@ -33,11 +33,12 @@ jobs:
         run: |
           rm -rf .next/e2e/myhost/cache/fetch-cache
           rm -rf .next/e2e/remote/cache/fetch-cache
+      - run: corepack enable pnpm
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
           cache: pnpm
-      - run: corepack enable pnpm && pnpm i
+      - run: pnpm i
       # https://github.com/FiloSottile/mkcert#linux
       - name: Install mkcert
         run: |

--- a/.github/workflows/_mutation-test.yml
+++ b/.github/workflows/_mutation-test.yml
@@ -17,11 +17,12 @@ jobs:
     if: github.head_ref == 'renovate/stryker-js-monorepo' || !startsWith(github.head_ref, 'renovate/')
     steps:
       - uses: actions/checkout@v4
+      - run: corepack enable pnpm
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
           cache: pnpm
-      - run: corepack enable pnpm && pnpm i
+      - run: pnpm i
       - run: pnpm _test:mutation:run --fileLogLevel trace
       - name: upload-reports
         run: |

--- a/.github/workflows/_mutation-test.yml
+++ b/.github/workflows/_mutation-test.yml
@@ -17,12 +17,11 @@ jobs:
     if: github.head_ref == 'renovate/stryker-js-monorepo' || !startsWith(github.head_ref, 'renovate/')
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
           cache: pnpm
-      - run: pnpm i
+      - run: corepack enable pnpm && pnpm i
       - run: pnpm _test:mutation:run --fileLogLevel trace
       - name: upload-reports
         run: |

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -9,6 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: corepack enable pnpm
+      - run: pnpm --version
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -9,7 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: corepack enable pnpm
-      - run: pnpm --version
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -8,11 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: corepack enable pnpm
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
           cache: pnpm
-      - run: corepack enable pnpm && pnpm i
+      - run: pnpm i
       - run: pnpm lint
       - run: pnpm test
       - run: pnpm playwright install --with-deps chromium

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -8,12 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
           cache: pnpm
-      - run: pnpm i
+      - run: corepack enable pnpm && pnpm i
       - run: pnpm lint
       - run: pnpm test
       - run: pnpm playwright install --with-deps chromium

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: corepack enable pnpm
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
@@ -46,7 +47,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/.next/cache
           key: nextjs-remote-${{ hashFiles('pnpm-lock.yaml') }}
-      - run: corepack enable pnpm && pnpm i
+      - run: pnpm i
       - run: pnpm build
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -38,7 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
@@ -47,7 +46,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/.next/cache
           key: nextjs-remote-${{ hashFiles('pnpm-lock.yaml') }}
-      - run: pnpm i
+      - run: corepack enable pnpm && pnpm i
       - run: pnpm build
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
Node16の警告が出続けるので

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: pnpm/action-setup@v2, changesets/action@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

