### PR TITLE
apRelayServiceリファクタリング

### DIFF
--- a/app/_shared/activitypub/apRelayService/service.spec.ts
+++ b/app/_shared/activitypub/apRelayService/service.spec.ts
@@ -1,10 +1,8 @@
-import type { Credential } from "@prisma/client";
-import { captor } from "jest-mock-extended";
 import { http, HttpResponse } from "msw";
 
-import { mockedKeys } from "@/_shared/mocks/keys";
-import { mockedPrisma } from "@/_shared/mocks/prisma";
+import type { apSchemaService } from "@/_shared/activitypub/apSchemaService";
 import { server } from "@/_shared/mocks/server";
+import { userSignUpService } from "@/_shared/user/services/userSignUpService";
 
 import { apReplayService } from ".";
 
@@ -16,99 +14,28 @@ jest.mock("@/../package.json", () => ({
 }));
 
 describe("apRelayService", () => {
-  describe("relayActivityToInboxUrl", () => {
-    test("正常系", async () => {
-      // arrange
-      const dummyUserId = "dummy_userId";
-      mockedPrisma.credential.findUnique.mockResolvedValueOnce({
-        privateKey: mockedKeys.privateKey,
-      } as Credential);
-      const headerFn = jest.fn();
-      const headerCaptor = captor();
-      const bodyFn = jest.fn();
-      const bodyCaptor = captor();
-      server.use(
-        http.post("https://remote.example.com/inbox", async ({ request }) => {
-          headerFn(Object.fromEntries(request.headers));
-          bodyFn(await request.json());
-          return new HttpResponse(null, { status: 202 });
-        }),
-      );
-      // act
-      await apReplayService.relayActivityToInboxUrl({
-        userId: dummyUserId,
-        inboxUrl: new URL("https://remote.example.com/inbox"),
-        activity: {
-          type: "Dummy",
-          actor: "https://myhost.example.com/users/dummy_other_userId/activity",
-        },
-      });
-      // assert
-      expect(headerFn).toHaveBeenCalledWith(headerCaptor);
-      expect(headerCaptor.value).toMatchSnapshot();
-      expect(bodyFn).toHaveBeenCalledWith(bodyCaptor);
-      expect(bodyCaptor.value).toEqual({
-        type: "Dummy",
-        actor: "https://myhost.example.com/users/dummy_other_userId/activity",
-      });
+  test("inboxUrlで指定したURLにActivityを配送する", async () => {
+    // arrange
+    const signer = await userSignUpService.signUpUser({
+      preferredUsername: "user",
+      password: "password",
     });
-  });
-
-  describe("relayActivityToFollowers", () => {
-    test("正常系", async () => {
-      // arrange
-      const dummyUserId = "dummy_userId";
-      mockedPrisma.follow.findMany.mockResolvedValue([
-        {
-          // @ts-ignore
-          follower: { inboxUrl: "https://remote1.example.com/users/foo/inbox" },
-        },
-        // @ts-ignore
-        { follower: { inboxUrl: "https://remote2.example.com/inbox" } },
-        // @ts-ignore
-        { follower: { inboxUrl: "https://remote2.example.com/inbox" } },
-        // @ts-ignore
-        { follower: { inboxUrl: null } },
-      ]);
-      mockedPrisma.credential.findUnique.mockResolvedValueOnce({
-        privateKey: mockedKeys.privateKey,
-      } as Credential);
-      const headerFn = jest.fn();
-      const headerCaptors = [captor(), captor()];
-      const bodyFn = jest.fn();
-      const bodyCaptors = [captor(), captor()];
-      const inbox1 = http.post(
-        "https://remote1.example.com/users/foo/inbox",
-        async ({ request }) => {
-          headerFn(Object.fromEntries(request.headers));
-          bodyFn(await request.json());
-          return new HttpResponse(null, { status: 202 });
-        },
-      );
-      const inbox2 = http.post(
-        "https://remote2.example.com/inbox",
-        async ({ request }) => {
-          headerFn(Object.fromEntries(request.headers));
-          bodyFn(await request.json());
-          return new HttpResponse(null, { status: 202 });
-        },
-      );
-      server.use(inbox1, inbox2);
-      // act
-      await apReplayService.relayActivityToFollowers({
-        userId: dummyUserId,
-        // @ts-ignore
-        activity: { type: "Dummy" },
-      });
-      // assert
-      expect(headerFn).toHaveBeenNthCalledWith(1, headerCaptors[0]);
-      expect(headerCaptors[0]!.value).toMatchSnapshot();
-      expect(headerFn).toHaveBeenNthCalledWith(2, headerCaptors[1]);
-      expect(headerCaptors[1]!.value).toMatchSnapshot();
-      expect(bodyFn).toHaveBeenCalledWith(bodyCaptors[0]);
-      expect(bodyCaptors[0]!.value).toEqual({ type: "Dummy" });
-      expect(bodyFn).toHaveBeenCalledWith(bodyCaptors[1]);
-      expect(bodyCaptors[1]!.value).toEqual({ type: "Dummy" });
+    const inboxUrl = "https://remote.example.com/inbox";
+    const activity = { type: "Dummy" } as unknown as apSchemaService.Activity;
+    const requestBodyFn = jest.fn();
+    server.use(
+      http.post(inboxUrl, async ({ request }) => {
+        requestBodyFn(await request.json());
+        return HttpResponse.text("Accepted", { status: 202 });
+      }),
+    );
+    // act
+    await apReplayService.relay({
+      signer,
+      activity,
+      inboxUrl,
     });
+    // assert
+    expect(requestBodyFn).toHaveBeenCalledWith(activity);
   });
 });

--- a/app/_shared/activitypub/apSchemaService/service.ts
+++ b/app/_shared/activitypub/apSchemaService/service.ts
@@ -171,3 +171,14 @@ export const createSchema = activitySchema.extend({
 });
 
 export type CreateActivity = z.infer<typeof createSchema>;
+
+export type Activity =
+  | AcceptActivity
+  | AnnounceActivity
+  | DeleteActivity
+  | FollowActivity
+  | LikeActivity
+  | NoteActivity
+  | PersonActivity
+  | UndoActivity
+  | CreateActivity;

--- a/app/_shared/activitypub/httpSignatureSignService/service.ts
+++ b/app/_shared/activitypub/httpSignatureSignService/service.ts
@@ -8,11 +8,13 @@ const getSignature = (textToSign: string, privateKey: string) => {
   return sig.sign(privateKey, "base64");
 };
 
+export type Signer = {
+  id: string;
+  privateKey: string;
+};
+
 export type SignActivityParams = {
-  signer: {
-    id: string;
-    privateKey: string;
-  };
+  signer: Signer;
   body: string;
   inboxUrl: URL;
   method: string;


### PR DESCRIPTION
重複した相手に配送されないようにする
前段階としてフォロワーを考慮して配送するapRelayService.relayを追加して、relayActivityToFollowersを廃止する
